### PR TITLE
test-ip6: skip ip6 case when CONFIG_NET_IPv6 disabled

### DIFF
--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -96,6 +96,9 @@ TEST_IMPL(getnameinfo_basic_ip6) {
 #if defined(__QEMU__)
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
+#ifndef CONFIG_NET_IPv6
+  RETURN_SKIP("Test depends on the CONFIG_NET_IPv6 configuration");
+#endif
   
   int r;
 

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -36,6 +36,9 @@ TEST_IMPL(ip6_addr_link_local) {
   /* FIXME: Does Cygwin support this?  */
   RETURN_SKIP("FIXME: This test needs more investigation on Cygwin");
 #endif
+#ifndef CONFIG_NET_IPv6
+  RETURN_SKIP("Test depends on the CONFIG_NET_IPv6 configuration");
+#endif
   char string_address[INET6_ADDRSTRLEN];
   uv_interface_address_t* addresses;
   uv_interface_address_t* address;


### PR DESCRIPTION
### Summary
The relevant configuration depends on CONFIG_NET_IPv6 options, so these two test cases need to be skipped when CONFIG_NET_IPv6 is not enabled.

### Impact
N/A

### Testing
Mainly on SIM.