### PR TITLE
memleak: Leaks a few bytes of memory when you call it with an unknown…

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -197,13 +197,10 @@ uv_buf_t uv_buf_init(char* base, unsigned int len) {
 
 
 static const char* uv__unknown_err_code(int err) {
-  char buf[32];
-  char* copy;
+  static char buf[32];
 
   snprintf(buf, sizeof(buf), "Unknown system error %d", err);
-  copy = uv__strdup(buf);
-
-  return copy != NULL ? copy : "Unknown system error";
+  return buf;
 }
 
 #define UV_ERR_NAME_GEN_R(name, _) \


### PR DESCRIPTION

## Summary

*Leaks a few bytes of memory when you call it with an unknown error code.*

## Impact

*print an unknown error code of libuv*

## Testing

*OS: Ubuntu 22.04.5 LTS
CPU: 12th Gen Intel® Core™ i7-12700 × 20
Compiler: G++13.1.0
Configuring NuttX and compile:
$ ./build.sh vendor/qemu/boards/smartspeaker/configs/smartspeaker -e -Werror -j8
Running with qemu
$ ./emulator.sh smartspeaker*

